### PR TITLE
Use .Any() instead of .Count() for Performance

### DIFF
--- a/RegExtract/RegExtractExtensions.cs
+++ b/RegExtract/RegExtractExtensions.cs
@@ -129,7 +129,7 @@ namespace RegExtract
 
             if (groupNames != null)
             {
-                hasNamedCaptures = 0 < groupNames.Where(gn => !int.TryParse(gn, out var _)).Count();
+                hasNamedCaptures = groupNames.Where(gn => !int.TryParse(gn, out var _)).Any();
                 numUnnamedCaptures = groupNames.Select((gn,i) => (gn, i)).Last(x => int.TryParse(x.gn, out var n) && n == x.i).i;
             }
 


### PR DESCRIPTION
`.Any()` fails quickly if when it finds the first instance of a `true`, so it is quicker than `.Count()` when checking for existence. Probably doesn't matter for the size of arrays we're talking about, but...