### PR TITLE
feat: parsing nullable regex pattern

### DIFF
--- a/RegExtract.Test/Usage.cs
+++ b/RegExtract.Test/Usage.cs
@@ -209,13 +209,13 @@ $
         }
 
         [Fact]
-        public void can_extract_multimatch_to_list()
+        public void can_extract_multimatch_to_tuple_as_list()
         {
-            var result = "123 456 789".Extract<List<int>> (@"(?:(\d+) ?)+");
+            var result = "123 456 789".Extract <List<int>> (@"(?:(\d+) ?)+");
         }
 
         [Fact]
-        public void can_extract_multimatch_to_hashset()
+        public void can_extract_multimatch_to_tuple_as_hashset()
         {
             var result = "123 456 789".Extract<HashSet<int>>(@"(?:(\d+) ?)+");
         }

--- a/RegExtract.Test/Usage.cs
+++ b/RegExtract.Test/Usage.cs
@@ -17,6 +17,12 @@ namespace RegExtract.Test
         const string pattern_named = "(?<n>(?<s>(?<a>.)(?<b>.)(?<c>.)(?<d>.)(?<e>.)(?<f>.)(?<g>.)(?<h>.)(?<i>.)))";
 
         [Fact]
+        public void can_parse_nullable_pattern()
+        {
+            "1 2".Extract<(int, int, int)>(@"(\d+)\s+(\d+)\s*(\d*)");
+        }
+
+        [Fact]
         public void can_parse_lookbehind()
         {
             data.Extract<string>(@"(?<=(12))");

--- a/RegExtract.Test/Usage.cs
+++ b/RegExtract.Test/Usage.cs
@@ -19,7 +19,7 @@ namespace RegExtract.Test
         [Fact]
         public void can_parse_nullable_pattern()
         {
-            "1 2".Extract<(int, int, int)>(@"(\d+)\s+(\d+)\s*(\d*)");
+            "12".Extract<(int, int, int?)>(@"(.)(.)(.)*");
         }
 
         [Fact]

--- a/RegExtract/ExtractionPlanNodeTypes.cs
+++ b/RegExtract/ExtractionPlanNodeTypes.cs
@@ -142,7 +142,7 @@ namespace RegExtract.ExtractionPlanNodeTypes
         {
             type = IsCollection(type) ? type.GetGenericArguments().Single() : type;
             type = IsNullable(type) ? type.GetGenericArguments().Single() : type;
-            if (Type.GetType($"{type.FullName}&") is null)
+            if (type.Namespace != "System")
             {
                 return type.GetMethod("Parse",
                     BindingFlags.Static | BindingFlags.Public,
@@ -155,7 +155,7 @@ namespace RegExtract.ExtractionPlanNodeTypes
             type.GetMethod("TryParse",
                 BindingFlags.Static | BindingFlags.Public,
                 null,
-                new Type[] { typeof(string), Type.GetType($"{type.FullName}&") ?? type },
+                new Type[] { typeof(string), Type.GetType($"{type.FullName}&") },
                 null
             ).Invoke(null, args);
             return args[1];

--- a/RegExtract/ExtractionPlanNodeTypes.cs
+++ b/RegExtract/ExtractionPlanNodeTypes.cs
@@ -142,14 +142,14 @@ namespace RegExtract.ExtractionPlanNodeTypes
         {
             type = IsCollection(type) ? type.GetGenericArguments().Single() : type;
             type = IsNullable(type) ? type.GetGenericArguments().Single() : type;
-
-            var parse = type.GetMethod("Parse",
+            var parse = type.GetMethod("TryParse",
                             BindingFlags.Static | BindingFlags.Public,
                             null,
-                            new Type[] { typeof(string) },
+                            new Type[] { typeof(string), Type.GetType($"{type.FullName}&") },
                             null);
-
-            return parse.Invoke(null, new object[] { range.Value });
+            var args = new object[] { range.Value, null! };
+            parse.Invoke(null, args);
+            return args[1];
         }
 
         internal override void Validate()

--- a/RegExtract/ExtractionPlanNodeTypes.cs
+++ b/RegExtract/ExtractionPlanNodeTypes.cs
@@ -142,13 +142,22 @@ namespace RegExtract.ExtractionPlanNodeTypes
         {
             type = IsCollection(type) ? type.GetGenericArguments().Single() : type;
             type = IsNullable(type) ? type.GetGenericArguments().Single() : type;
-            var parse = type.GetMethod("TryParse",
-                            BindingFlags.Static | BindingFlags.Public,
-                            null,
-                            new Type[] { typeof(string), Type.GetType($"{type.FullName}&") },
-                            null);
+            if (Type.GetType($"{type.FullName}&") is null)
+            {
+                return type.GetMethod("Parse",
+                    BindingFlags.Static | BindingFlags.Public,
+                    null,
+                    new Type[] { typeof(string) },
+                    null
+                ).Invoke(null, new object[] { range.Value });
+            }
             var args = new object[] { range.Value, null! };
-            parse.Invoke(null, args);
+            type.GetMethod("TryParse",
+                BindingFlags.Static | BindingFlags.Public,
+                null,
+                new Type[] { typeof(string), Type.GetType($"{type.FullName}&") ?? type },
+                null
+            ).Invoke(null, args);
             return args[1];
         }
 


### PR DESCRIPTION
The library does not support nullable regex pattern afaik. And I happen to have a use case for it.

This PR should be able to parse such patterns, e.g:

```csharp
"12".Extract<(int, int, int)>(@"(.)(.)(.)*"); // would throw "Null object cannot be converted to a value type."
"12".Extract<(int, int, int?)>(@"(.)(.)(.)"); // would throw "Regex didn't match"
"12".Extract<(int, int, int?)>(@"(.)(.)(.)*"); // would return (1, 2, null).
```