### PR TITLE
feat: add Try-prefixed methods

### DIFF
--- a/RegExtract.Test/Usage.cs
+++ b/RegExtract.Test/Usage.cs
@@ -17,6 +17,35 @@ namespace RegExtract.Test
         const string pattern_named = "(?<n>(?<s>(?<a>.)(?<b>.)(?<c>.)(?<d>.)(?<e>.)(?<f>.)(?<g>.)(?<h>.)(?<i>.)))";
 
         [Fact]
+        public void can_try_extract_to_tuple()
+        {
+            var plan = ExtractionPlan<(int a, char b, string c, int d, char e, string f, int g, char h, string i)>.CreatePlan(new Regex(pattern));
+            var ok = plan.TryExtract(data, out var extracted);
+
+            Assert.True(ok);
+
+            Assert.IsType<int>(extracted.a);
+            Assert.IsType<char>(extracted.b);
+            Assert.IsType<string>(extracted.c);
+            Assert.IsType<int>(extracted.d);
+            Assert.IsType<char>(extracted.e);
+            Assert.IsType<string>(extracted.f);
+            Assert.IsType<int>(extracted.g);
+            Assert.IsType<char>(extracted.h);
+            Assert.IsType<string>(extracted.i);
+
+            Assert.Equal(1, extracted.a);
+            Assert.Equal('2', extracted.b);
+            Assert.Equal("3", extracted.c);
+            Assert.Equal(4, extracted.d);
+            Assert.Equal('5', extracted.e);
+            Assert.Equal("6", extracted.f);
+            Assert.Equal(7, extracted.g);
+            Assert.Equal('8', extracted.h);
+            Assert.Equal("9", extracted.i);
+        }
+
+        [Fact]
         public void can_parse_lookbehind()
         {
             data.Extract<string>(@"(?<=(12))");
@@ -140,7 +169,7 @@ namespace RegExtract.Test
         }
 
         // Don't currently handle nested named captures, and I'm not sure we ever will.
-        //[Fact]
+        // [Fact]
         //public void can_extract_named_capture_groups_to_properties()
         //{
         //    PropertiesRecord? record = data.Extract<PropertiesRecord>(pattern_named);

--- a/RegExtract.Test/Usage.cs
+++ b/RegExtract.Test/Usage.cs
@@ -17,6 +17,33 @@ namespace RegExtract.Test
         const string pattern_named = "(?<n>(?<s>(?<a>.)(?<b>.)(?<c>.)(?<d>.)(?<e>.)(?<f>.)(?<g>.)(?<h>.)(?<i>.)))";
 
         [Fact]
+        public void can_try_extract_to_tuple_using_extension()
+        {
+            var ok = data.TryExtract<(int a, char b, string c, int d, char e, string f, int g, char h, string i)>(pattern, out var extracted);
+
+            Assert.True(ok);
+
+            Assert.IsType<int>(extracted.a);
+            Assert.IsType<char>(extracted.b);
+            Assert.IsType<string>(extracted.c);
+            Assert.IsType<int>(extracted.d);
+            Assert.IsType<char>(extracted.e);
+            Assert.IsType<string>(extracted.f);
+            Assert.IsType<int>(extracted.g);
+            Assert.IsType<char>(extracted.h);
+            Assert.IsType<string>(extracted.i);
+
+            Assert.Equal(1, extracted.a);
+            Assert.Equal('2', extracted.b);
+            Assert.Equal("3", extracted.c);
+            Assert.Equal(4, extracted.d);
+            Assert.Equal('5', extracted.e);
+            Assert.Equal("6", extracted.f);
+            Assert.Equal(7, extracted.g);
+            Assert.Equal('8', extracted.h);
+            Assert.Equal("9", extracted.i);
+        }
+        [Fact]
         public void can_try_extract_to_tuple()
         {
             var plan = ExtractionPlan<(int a, char b, string c, int d, char e, string f, int g, char h, string i)>.CreatePlan(new Regex(pattern));

--- a/RegExtract/ExtractionPlan.cs
+++ b/RegExtract/ExtractionPlan.cs
@@ -31,6 +31,28 @@ namespace RegExtract
             return (T)Plan.Execute(match)!;
         }
 
+        public bool TryExtract(string str, out T result)
+        {
+            result = default!;
+            if (!Plan.TryExecute(_tree?.Regex.Match(str) ?? Regex.Match("",""), out var temp))
+            {
+                return false;
+            }
+            result = (T)temp!;
+            return true;
+        }
+
+        public bool TryExtract(Match match, out T result)
+        {
+            result = default!;
+            if (!Plan.TryExecute(match, out var temp))
+            {
+                return false;
+            }
+            result = (T)temp!;
+            return true;
+        }
+
         static public ExtractionPlan<T> CreatePlan(Regex regex, RegExtractOptions reOptions= RegExtractOptions.None)
         {
             ExtractionPlan<T> plan = new ExtractionPlan<T>();

--- a/RegExtract/ExtractionPlanNode.cs
+++ b/RegExtract/ExtractionPlanNode.cs
@@ -125,7 +125,7 @@ namespace RegExtract
             if (IsCollection(innerType))
                 throw new ArgumentException("List of lists in type cannot be bound to leaf of regex capture group tree.");
             else if (IsTuple(innerType))
-                throw new ArgumentException("Tuple in type cannot be bound to leaf of regex capture group tree." + innerType.Name);
+                throw new ArgumentException("Tuple in type cannot be bound to leaf of regex capture group tree.");
             else if (staticParseMethod is not null)
                 node = new StaticParseMethodNode(groupName, type, constructorParams, propertySetters);
             else if (stringConstructor is not null)

--- a/RegExtract/RegExtractExtensions.cs
+++ b/RegExtract/RegExtractExtensions.cs
@@ -81,11 +81,87 @@ namespace RegExtract
             var rx = GetRegexFromType(typeof(T));
             return Extract<T>(str, rx, options);
         }
-        
+
         public static IEnumerable<T> Extract<T>(this IEnumerable<string> str, Regex rx, RegExtractOptions options = RegExtractOptions.None)
         {
             var plan = ExtractionPlan<T>.CreatePlan(rx, options);
             return str.Select(s => plan.Extract(rx.Match(s)));
+        }
+
+        public static bool TryExtract<T>(this string str, string rx, out T result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            return TryExtract<T>(str, rx, RegexOptions.None, out result, options);
+        }
+
+        public static bool TryExtract<T>(this string str, string rx, RegexOptions rxOptions, out T result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            var match = Regex.Match(str, rx, rxOptions);
+
+            var plan = ExtractionPlan<T>.CreatePlan(new Regex(rx));
+            return plan.TryExtract(match, out result);
+        }
+
+        public static bool TryExtract<T>(this string str, Regex rx, out T result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            var match = rx.Match(str);
+            var plan = ExtractionPlan<T>.CreatePlan(rx);
+            return plan.TryExtract(match, out result);
+        }
+
+        public static bool TryExtract<T>(this string str, ExtractionPlan<T> plan, out T result)
+        {
+            return plan.TryExtract(str, out result);
+        }
+
+        public static bool TryExtract<T>(this string str, out T result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            return TryExtract(str, GetRegexFromType(typeof(T)), out result, options);
+        }
+
+        public static bool TryExtract<T>(this IEnumerable<string> str, string rx, out IEnumerable<T> result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            return TryExtract(str, rx, RegexOptions.None, out result, options);
+        }
+
+        public static bool TryExtract<T>(this IEnumerable<string> str, string rx, RegexOptions rxOptions, out IEnumerable<T> result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            return TryExtract(str, new Regex(rx, rxOptions), out result, options);
+        }
+
+        public static bool TryExtract<T>(this IEnumerable<string> str, ExtractionPlan<T> plan, out IEnumerable<T> result)
+        {
+            var anyFailure = false;
+            result = str.Select(s =>
+            {
+                if (plan.TryExtract(s, out var result))
+                {
+                    return result;
+                }
+                anyFailure = true;
+                return default!;
+            });
+            return anyFailure;
+        }
+
+        public static bool TryExtract<T>(this IEnumerable<string> str, out IEnumerable<T> result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            return TryExtract(str, GetRegexFromType(typeof(T)), out result, options);
+        }
+
+        public static bool TryExtract<T>(this IEnumerable<string> str, Regex rx, out IEnumerable<T> result, RegExtractOptions options = RegExtractOptions.None)
+        {
+            var plan = ExtractionPlan<T>.CreatePlan(rx, options);
+            var anyFailure = false;
+            result = str.Select(s =>
+            {
+                if (plan.TryExtract(rx.Match(s), out var result))
+                {
+                    return result;
+                }
+                anyFailure = true;
+                return default!;
+            });
+            return anyFailure;
         }
     }
 }


### PR DESCRIPTION
This PR adds Try-prefixed methods, including: `TryConstruct`, `TryExecute`, `TryExtract`.